### PR TITLE
Change how invoice email is done to an observer event

### DIFF
--- a/src/app/code/community/Fontis/EwayAu/Model/Direct.php
+++ b/src/app/code/community/Fontis/EwayAu/Model/Direct.php
@@ -374,26 +374,4 @@ class Fontis_EwayAu_Model_Direct extends Mage_Payment_Model_Method_Cc
 
         return $newResArr;
     }
-    
-    /**
-     * Check if invoice email can be sent, and send it
-     * 
-     * @param Mage_Sales_Model_Order_Invoice $invoice
-     * @param Mage_Sales_Model_Order_Payment $payment
-     * @return Fontis_EwayAu_Model_Direct
-     */
-    public function processInvoice($invoice, $payment)
-    {
-        parent::processInvoice($invoice, $payment);
-        try {
-            $storeId = $invoice->getOrder()->getStoreId();
-            if (Mage::helper('sales')->canSendNewInvoiceEmail($storeId)) {
-                $invoice->save();
-                $invoice->sendEmail();
-            }
-        } catch (Exception $e) {
-            mage::logException($e);
-        }    
-        return $this;
-    }
 }

--- a/src/app/code/community/Fontis/EwayAu/Model/Observer.php
+++ b/src/app/code/community/Fontis/EwayAu/Model/Observer.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Fontis eWAY Australia payment gateway
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magentocommerce.com so you can be sent a copy immediately.
+ *
+ * Original code copyright (c) 2008 Irubin Consulting Inc. DBA Varien
+ *
+ * @category   Fontis
+ * @package    Fontis_EwayAu
+ * @copyright  Copyright (c) 2010 Fontis (http://www.fontis.com.au)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+/**
+ * Observer to handle invoice email sending after payment was completed
+ * 
+ * @author     Lucas van Staden (support@proxiblue.com.au)
+ * */
+class Fontis_EwayAu_Model_Observer {
+
+    /**
+     * Email invoice when all order objects have been completed
+     * 
+     * @param type $observer
+     */
+    public function checkout_submit_all_after($observer) {
+        $order = $observer->getOrder();
+        if ($order->hasInvoices()) {
+            foreach ($order->getInvoiceCollection() as $invoice) {
+                // email out the invoices 
+                try {
+                    $storeId = $invoice->getOrder()->getStoreId();
+                    if (Mage::helper('sales')->canSendNewInvoiceEmail($storeId)) {
+                        $invoice->sendEmail();
+                    }
+                } catch (Exception $e) {
+                    mage::logException($e);
+                }
+            }
+        }
+        return $this;
+    }
+
+}

--- a/src/app/code/community/Fontis/EwayAu/etc/config.xml
+++ b/src/app/code/community/Fontis/EwayAu/etc/config.xml
@@ -74,6 +74,17 @@
                 </types>
             </cc>
         </payment>
+        <events>
+            <checkout_submit_all_after>
+                <observers>
+                    <ewayau_checkout_submit_all_after>
+                        <type>singleton</type>
+                        <class>ewayau/observer</class>
+                        <method>checkout_submit_all_after</method>
+                    </ewayau_checkout_submit_all_after>
+                </observers>
+            </checkout_submit_all_after>
+        </events>
     </global>
     <frontend>
         <secure_url>


### PR DESCRIPTION
Changed how the order invoice emails are sent.

The current way using Fontis_EwayAu_Model_Direct::processInvoice is flawed.

Customers mistake the invoice email for the success email, as it is received first.

If something happens during the order process, (after this method is called) the client will receive an email with the invoice, which states an invoice id for them.
If (for some reason) the reserved invoice id is rolled back, you will find two clients with emails that have the same invoice id. (This has occurred on a site recently, which prompted this change)

The sending has been moved to an event that runs after the order objects have been successfully created and saved.
This then also negates the need to force save the invoice object (as per old code)
